### PR TITLE
Fix typo in language name

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ As of now this repository is used to keep track of the current mutation testing 
 * Clojure
   * [mutant](https://github.com/jstepien/mutant)
   * [ds2643/mutcl](https://github.com/ds2643/mutcl) [abandoned]
-* Elexir
+* Elixir
   * [JordiPolo/mutation](https://github.com/JordiPolo/mutation)
 * Go
   * [zimmski/go-mutesting](https://github.com/zimmski/go-mutesting)


### PR DESCRIPTION
see https://elixir-lang.org/