### PR TITLE
Add crytic library for crystal-lang

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ As of now this repository is used to keep track of the current mutation testing 
 * Clojure
   * [mutant](https://github.com/jstepien/mutant)
   * [ds2643/mutcl](https://github.com/ds2643/mutcl) [abandoned]
+* Crystal
+  * [crytic](https://github.com/hanneskaeufler/crytic)
 * Elixir
   * [JordiPolo/mutation](https://github.com/JordiPolo/mutation)
 * Go


### PR DESCRIPTION
This is a shameless plug but being into all sorts of testing and figuring there was no mutation test tool for crystal lang, needless to say I created my own to learn more about mutation testing. Would love to see it listed here.